### PR TITLE
Implement smtlib2 overflow predicates

### DIFF
--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -122,6 +122,9 @@ void bv_decl_plugin::finalize() {
     DEC_REF(m_bv_smul_no_ovfl);
     DEC_REF(m_bv_smul_no_udfl);
 
+    DEC_REF(m_bv_mul_ovfl);
+    DEC_REF(m_bv_smul_ovfl);
+
     DEC_REF(m_bv_shl);
     DEC_REF(m_bv_lshr);
     DEC_REF(m_bv_ashr);
@@ -330,6 +333,8 @@ func_decl * bv_decl_plugin::mk_func_decl(decl_kind k, unsigned bv_size) {
     case OP_BUMUL_NO_OVFL: return mk_pred(m_bv_mul_no_ovfl, k, "bvumul_noovfl", bv_size);
     case OP_BSMUL_NO_OVFL: return mk_pred(m_bv_smul_no_ovfl, k, "bvsmul_noovfl", bv_size);
     case OP_BSMUL_NO_UDFL: return mk_pred(m_bv_smul_no_udfl, k, "bvsmul_noudfl", bv_size);
+    case OP_BUMUL_OVFL: return mk_pred(m_bv_mul_ovfl, k, "bvumulo", bv_size);
+    case OP_BSMUL_OVFL: return mk_pred(m_bv_smul_ovfl, k, "bvsmulo", bv_size);
 
     case OP_BSHL:     return mk_binary(m_bv_shl, k, "bvshl", bv_size, false);
     case OP_BLSHR:    return mk_binary(m_bv_lshr, k, "bvlshr", bv_size, false);
@@ -724,6 +729,9 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
         op_names.push_back(builtin_name("bvumul_noovfl",OP_BUMUL_NO_OVFL));
         op_names.push_back(builtin_name("bvsmul_noovfl",OP_BSMUL_NO_OVFL));
         op_names.push_back(builtin_name("bvsmul_noudfl",OP_BSMUL_NO_UDFL));
+
+        op_names.push_back(builtin_name("bvumulo",OP_BUMUL_OVFL));
+        op_names.push_back(builtin_name("bvsmulo",OP_BSMUL_OVFL));
 
         op_names.push_back(builtin_name("bvsdiv0", OP_BSDIV0));
         op_names.push_back(builtin_name("bvudiv0", OP_BUDIV0));

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -118,9 +118,9 @@ void bv_decl_plugin::finalize() {
     DEC_REF(m_bv_redand);
     DEC_REF(m_bv_comp);
 
-    DEC_REF(m_bv_mul_ovfl);
-    DEC_REF(m_bv_smul_ovfl);
-    DEC_REF(m_bv_smul_udfl);
+    DEC_REF(m_bv_mul_no_ovfl);
+    DEC_REF(m_bv_smul_no_ovfl);
+    DEC_REF(m_bv_smul_no_udfl);
 
     DEC_REF(m_bv_shl);
     DEC_REF(m_bv_lshr);
@@ -327,9 +327,9 @@ func_decl * bv_decl_plugin::mk_func_decl(decl_kind k, unsigned bv_size) {
     case OP_BREDOR:   return mk_reduction(m_bv_redor, k, "bvredor", bv_size);
     case OP_BREDAND:  return mk_reduction(m_bv_redand, k, "bvredand", bv_size);
     case OP_BCOMP:    return mk_comp(bv_size);
-    case OP_BUMUL_NO_OVFL: return mk_pred(m_bv_mul_ovfl, k, "bvumul_noovfl", bv_size);
-    case OP_BSMUL_NO_OVFL: return mk_pred(m_bv_smul_ovfl, k, "bvsmul_noovfl", bv_size);
-    case OP_BSMUL_NO_UDFL: return mk_pred(m_bv_smul_udfl, k, "bvsmul_noudfl", bv_size);
+    case OP_BUMUL_NO_OVFL: return mk_pred(m_bv_mul_no_ovfl, k, "bvumul_noovfl", bv_size);
+    case OP_BSMUL_NO_OVFL: return mk_pred(m_bv_smul_no_ovfl, k, "bvsmul_noovfl", bv_size);
+    case OP_BSMUL_NO_UDFL: return mk_pred(m_bv_smul_no_udfl, k, "bvsmul_noudfl", bv_size);
 
     case OP_BSHL:     return mk_binary(m_bv_shl, k, "bvshl", bv_size, false);
     case OP_BLSHR:    return mk_binary(m_bv_lshr, k, "bvlshr", bv_size, false);

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -689,6 +689,8 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
     op_names.push_back(builtin_name("bvadd",OP_BADD));
     op_names.push_back(builtin_name("bvsub",OP_BSUB));
     op_names.push_back(builtin_name("bvmul",OP_BMUL));
+    op_names.push_back(builtin_name("bvumulo",OP_BUMUL_OVFL));
+    op_names.push_back(builtin_name("bvsmulo",OP_BSMUL_OVFL));
     op_names.push_back(builtin_name("bvsdiv",OP_BSDIV));
     op_names.push_back(builtin_name("bvudiv",OP_BUDIV));
     op_names.push_back(builtin_name("bvsrem",OP_BSREM));
@@ -729,9 +731,6 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
         op_names.push_back(builtin_name("bvumul_noovfl",OP_BUMUL_NO_OVFL));
         op_names.push_back(builtin_name("bvsmul_noovfl",OP_BSMUL_NO_OVFL));
         op_names.push_back(builtin_name("bvsmul_noudfl",OP_BSMUL_NO_UDFL));
-
-        op_names.push_back(builtin_name("bvumulo",OP_BUMUL_OVFL));
-        op_names.push_back(builtin_name("bvsmulo",OP_BSMUL_OVFL));
 
         op_names.push_back(builtin_name("bvsdiv0", OP_BSDIV0));
         op_names.push_back(builtin_name("bvudiv0", OP_BUDIV0));

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -248,6 +248,16 @@ func_decl * bv_decl_plugin::mk_bv2int(unsigned bv_size, unsigned num_parameters,
     return m_bv2int[bv_size];
 }
 
+func_decl * bv_decl_plugin::mk_unary_pred(ptr_vector<func_decl> & decls, decl_kind k, char const * name, unsigned bv_size) {
+    force_ptr_array_size(decls, bv_size+1);
+
+    if (decls[bv_size] == 0) {
+        decls[bv_size] = m_manager->mk_func_decl(symbol(name), get_bv_sort(bv_size), m_manager->mk_bool_sort(), func_decl_info(m_family_id, k));
+        m_manager->inc_ref(decls[bv_size]);
+    }
+    return decls[bv_size];
+}
+
 func_decl * bv_decl_plugin::mk_pred(ptr_vector<func_decl> & decls, decl_kind k, char const * name, unsigned bv_size) {
     force_ptr_array_size(decls, bv_size + 1);
 

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -346,6 +346,7 @@ func_decl * bv_decl_plugin::mk_func_decl(decl_kind k, unsigned bv_size) {
     case OP_BSMUL_NO_UDFL: return mk_pred(m_bv_smul_no_udfl, k, "bvsmul_noudfl", bv_size);
     case OP_BUMUL_OVFL: return mk_pred(m_bv_mul_ovfl, k, "bvumulo", bv_size);
     case OP_BSMUL_OVFL: return mk_pred(m_bv_smul_ovfl, k, "bvsmulo", bv_size);
+    case OP_BSDIV_OVFL: return mk_pred(m_bv_sdiv_ovfl, k, "bvsdivo", bv_size);
     case OP_BUADD_OVFL: return mk_pred(m_bv_uadd_ovfl, k, "bvuaddo", bv_size);
     case OP_BSADD_OVFL: return mk_pred(m_bv_sadd_ovfl, k, "bvsaddo", bv_size);
     case OP_BUSUB_OVFL: return mk_pred(m_bv_usub_ovfl, k, "bvusubo", bv_size);
@@ -712,6 +713,7 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
     op_names.push_back(builtin_name("bvumulo",OP_BUMUL_OVFL));
     op_names.push_back(builtin_name("bvsmulo",OP_BSMUL_OVFL));
     op_names.push_back(builtin_name("bvsdiv",OP_BSDIV));
+    op_names.push_back(builtin_name("bvsdivo",OP_BSDIV_OVFL));
     op_names.push_back(builtin_name("bvudiv",OP_BUDIV));
     op_names.push_back(builtin_name("bvsrem",OP_BSREM));
     op_names.push_back(builtin_name("bvurem",OP_BUREM));

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -348,6 +348,7 @@ func_decl * bv_decl_plugin::mk_func_decl(decl_kind k, unsigned bv_size) {
     case OP_BSMUL_OVFL: return mk_pred(m_bv_smul_ovfl, k, "bvsmulo", bv_size);
     case OP_BUADD_OVFL: return mk_pred(m_bv_uadd_ovfl, k, "bvuaddo", bv_size);
     case OP_BSADD_OVFL: return mk_pred(m_bv_sadd_ovfl, k, "bvsaddo", bv_size);
+    case OP_BUSUB_OVFL: return mk_pred(m_bv_usub_ovfl, k, "bvusubo", bv_size);
 
     case OP_BSHL:     return mk_binary(m_bv_shl, k, "bvshl", bv_size, false);
     case OP_BLSHR:    return mk_binary(m_bv_lshr, k, "bvlshr", bv_size, false);
@@ -704,6 +705,7 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
     op_names.push_back(builtin_name("bvuaddo",OP_BUADD_OVFL));
     op_names.push_back(builtin_name("bvsaddo",OP_BSADD_OVFL));
     op_names.push_back(builtin_name("bvsub",OP_BSUB));
+    op_names.push_back(builtin_name("bvusubo",OP_BUSUB_OVFL));
     op_names.push_back(builtin_name("bvmul",OP_BMUL));
     op_names.push_back(builtin_name("bvumulo",OP_BUMUL_OVFL));
     op_names.push_back(builtin_name("bvsmulo",OP_BSMUL_OVFL));

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -302,6 +302,7 @@ func_decl * bv_decl_plugin::mk_comp(unsigned bv_size) {
 func_decl * bv_decl_plugin::mk_func_decl(decl_kind k, unsigned bv_size) {
     switch (k) {
     case OP_BNEG:     return mk_unary(m_bv_neg, k, "bvneg", bv_size);
+    case OP_BNEG_OVFL: return mk_unary_pred(m_bv_neg_ovfl, k, "bvnego", bv_size);
     case OP_BADD:     return mk_binary(m_bv_add, k, "bvadd", bv_size, true);
     case OP_BSUB:     return mk_binary(m_bv_sub, k, "bvsub", bv_size, false);
     case OP_BMUL:     return mk_binary(m_bv_mul, k, "bvmul", bv_size, true);
@@ -696,6 +697,7 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
     op_names.push_back(builtin_name("bit1",OP_BIT1));
     op_names.push_back(builtin_name("bit0",OP_BIT0));
     op_names.push_back(builtin_name("bvneg",OP_BNEG));
+    op_names.push_back(builtin_name("bvnego", OP_BNEG_OVFL));
     op_names.push_back(builtin_name("bvadd",OP_BADD));
     op_names.push_back(builtin_name("bvsub",OP_BSUB));
     op_names.push_back(builtin_name("bvmul",OP_BMUL));

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -347,6 +347,7 @@ func_decl * bv_decl_plugin::mk_func_decl(decl_kind k, unsigned bv_size) {
     case OP_BUMUL_OVFL: return mk_pred(m_bv_mul_ovfl, k, "bvumulo", bv_size);
     case OP_BSMUL_OVFL: return mk_pred(m_bv_smul_ovfl, k, "bvsmulo", bv_size);
     case OP_BUADD_OVFL: return mk_pred(m_bv_uadd_ovfl, k, "bvuaddo", bv_size);
+    case OP_BSADD_OVFL: return mk_pred(m_bv_sadd_ovfl, k, "bvsaddo", bv_size);
 
     case OP_BSHL:     return mk_binary(m_bv_shl, k, "bvshl", bv_size, false);
     case OP_BLSHR:    return mk_binary(m_bv_lshr, k, "bvlshr", bv_size, false);
@@ -701,6 +702,7 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
     op_names.push_back(builtin_name("bvnego", OP_BNEG_OVFL));
     op_names.push_back(builtin_name("bvadd",OP_BADD));
     op_names.push_back(builtin_name("bvuaddo",OP_BUADD_OVFL));
+    op_names.push_back(builtin_name("bvsaddo",OP_BSADD_OVFL));
     op_names.push_back(builtin_name("bvsub",OP_BSUB));
     op_names.push_back(builtin_name("bvmul",OP_BMUL));
     op_names.push_back(builtin_name("bvumulo",OP_BUMUL_OVFL));

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -346,6 +346,7 @@ func_decl * bv_decl_plugin::mk_func_decl(decl_kind k, unsigned bv_size) {
     case OP_BSMUL_NO_UDFL: return mk_pred(m_bv_smul_no_udfl, k, "bvsmul_noudfl", bv_size);
     case OP_BUMUL_OVFL: return mk_pred(m_bv_mul_ovfl, k, "bvumulo", bv_size);
     case OP_BSMUL_OVFL: return mk_pred(m_bv_smul_ovfl, k, "bvsmulo", bv_size);
+    case OP_BUADD_OVFL: return mk_pred(m_bv_uadd_ovfl, k, "bvuaddo", bv_size);
 
     case OP_BSHL:     return mk_binary(m_bv_shl, k, "bvshl", bv_size, false);
     case OP_BLSHR:    return mk_binary(m_bv_lshr, k, "bvlshr", bv_size, false);
@@ -699,6 +700,7 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
     op_names.push_back(builtin_name("bvneg",OP_BNEG));
     op_names.push_back(builtin_name("bvnego", OP_BNEG_OVFL));
     op_names.push_back(builtin_name("bvadd",OP_BADD));
+    op_names.push_back(builtin_name("bvuaddo",OP_BUADD_OVFL));
     op_names.push_back(builtin_name("bvsub",OP_BSUB));
     op_names.push_back(builtin_name("bvmul",OP_BMUL));
     op_names.push_back(builtin_name("bvumulo",OP_BUMUL_OVFL));

--- a/src/ast/bv_decl_plugin.cpp
+++ b/src/ast/bv_decl_plugin.cpp
@@ -349,6 +349,7 @@ func_decl * bv_decl_plugin::mk_func_decl(decl_kind k, unsigned bv_size) {
     case OP_BUADD_OVFL: return mk_pred(m_bv_uadd_ovfl, k, "bvuaddo", bv_size);
     case OP_BSADD_OVFL: return mk_pred(m_bv_sadd_ovfl, k, "bvsaddo", bv_size);
     case OP_BUSUB_OVFL: return mk_pred(m_bv_usub_ovfl, k, "bvusubo", bv_size);
+    case OP_BSSUB_OVFL: return mk_pred(m_bv_ssub_ovfl, k, "bvssubo", bv_size);
 
     case OP_BSHL:     return mk_binary(m_bv_shl, k, "bvshl", bv_size, false);
     case OP_BLSHR:    return mk_binary(m_bv_lshr, k, "bvlshr", bv_size, false);
@@ -706,6 +707,7 @@ void bv_decl_plugin::get_op_names(svector<builtin_name> & op_names, symbol const
     op_names.push_back(builtin_name("bvsaddo",OP_BSADD_OVFL));
     op_names.push_back(builtin_name("bvsub",OP_BSUB));
     op_names.push_back(builtin_name("bvusubo",OP_BUSUB_OVFL));
+    op_names.push_back(builtin_name("bvssubo",OP_BSSUB_OVFL));
     op_names.push_back(builtin_name("bvmul",OP_BMUL));
     op_names.push_back(builtin_name("bvumulo",OP_BUMUL_OVFL));
     op_names.push_back(builtin_name("bvsmulo",OP_BSMUL_OVFL));

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -189,9 +189,9 @@ protected:
     ptr_vector<func_decl>  m_bv_redand;
     ptr_vector<func_decl>  m_bv_comp;
 
-    ptr_vector<func_decl>  m_bv_mul_ovfl;
-    ptr_vector<func_decl>  m_bv_smul_ovfl;
-    ptr_vector<func_decl>  m_bv_smul_udfl;
+    ptr_vector<func_decl>  m_bv_mul_no_ovfl;
+    ptr_vector<func_decl>  m_bv_smul_no_ovfl;
+    ptr_vector<func_decl>  m_bv_smul_no_udfl;
 
     ptr_vector<func_decl>  m_bv_shl;
     ptr_vector<func_decl>  m_bv_lshr;

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -99,6 +99,7 @@ enum bv_op_kind {
     OP_BNEG_OVFL, // negation overflow predicate
 
     OP_BUADD_OVFL, // unsigned addition overflow predicate
+    OP_BSADD_OVFL, // signed addition overflow predicate
 
     OP_BIT2BOOL, // predicate
     OP_MKBV,     // bools to bv
@@ -206,6 +207,7 @@ protected:
     ptr_vector<func_decl> m_bv_neg_ovfl;
 
     ptr_vector<func_decl> m_bv_uadd_ovfl;
+    ptr_vector<func_decl> m_bv_sadd_ovfl;
 
     ptr_vector<func_decl>  m_bv_shl;
     ptr_vector<func_decl>  m_bv_lshr;
@@ -513,6 +515,7 @@ public:
     app * mk_bvumul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_OVFL, n, m); }
     app * mk_bvneg_ovfl(expr* m) { return m_manager.mk_app(get_fid(), OP_BNEG_OVFL, m); }
     app * mk_bvuadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUADD_OVFL, n, m); }
+    app * mk_bvsadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSADD_OVFL, n, m); }
 
     app * mk_bit2bool(expr* e, unsigned idx) { parameter p(idx); return m_manager.mk_app(get_fid(), OP_BIT2BOOL, 1, &p, 1, &e); }
 

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -101,6 +101,8 @@ enum bv_op_kind {
     OP_BUADD_OVFL, // unsigned addition overflow predicate
     OP_BSADD_OVFL, // signed addition overflow predicate
 
+    OP_BUSUB_OVFL, // unsigned subtraction overflow predicate
+
     OP_BIT2BOOL, // predicate
     OP_MKBV,     // bools to bv
     OP_INT2BV,
@@ -208,6 +210,8 @@ protected:
 
     ptr_vector<func_decl> m_bv_uadd_ovfl;
     ptr_vector<func_decl> m_bv_sadd_ovfl;
+
+    ptr_vector<func_decl> m_bv_usub_ovfl;
 
     ptr_vector<func_decl>  m_bv_shl;
     ptr_vector<func_decl>  m_bv_lshr;
@@ -516,6 +520,7 @@ public:
     app * mk_bvneg_ovfl(expr* m) { return m_manager.mk_app(get_fid(), OP_BNEG_OVFL, m); }
     app * mk_bvuadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUADD_OVFL, n, m); }
     app * mk_bvsadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSADD_OVFL, n, m); }
+    app * mk_bvusub_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUSUB_OVFL, m, n); }
 
     app * mk_bit2bool(expr* e, unsigned idx) { parameter p(idx); return m_manager.mk_app(get_fid(), OP_BIT2BOOL, 1, &p, 1, &e); }
 

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -93,6 +93,9 @@ enum bv_op_kind {
     OP_BSMUL_NO_OVFL, // no signed multiplication overflow predicate
     OP_BSMUL_NO_UDFL, // no signed multiplication underflow predicate
 
+    OP_BUMUL_OVFL, // unsigned multiplication overflow predicate (negation of OP_BUMUL_NO_OVFL)
+    OP_BSMUL_OVFL, // signed multiplication over/underflow predicate
+
     OP_BIT2BOOL, // predicate
     OP_MKBV,     // bools to bv
     OP_INT2BV,
@@ -192,6 +195,9 @@ protected:
     ptr_vector<func_decl>  m_bv_mul_no_ovfl;
     ptr_vector<func_decl>  m_bv_smul_no_ovfl;
     ptr_vector<func_decl>  m_bv_smul_no_udfl;
+
+    ptr_vector<func_decl> m_bv_mul_ovfl;
+    ptr_vector<func_decl> m_bv_smul_ovfl;
 
     ptr_vector<func_decl>  m_bv_shl;
     ptr_vector<func_decl>  m_bv_lshr;
@@ -493,6 +499,8 @@ public:
     app * mk_bvsmul_no_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSMUL_NO_OVFL, n, m); }
     app * mk_bvsmul_no_udfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSMUL_NO_UDFL, n, m); }
     app * mk_bvumul_no_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_NO_OVFL, n, m); }
+    app * mk_bvsmul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSMUL_OVFL, n, m); }
+    app * mk_bvumul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_OVFL, n, m); }
     app * mk_bit2bool(expr* e, unsigned idx) { parameter p(idx); return m_manager.mk_app(get_fid(), OP_BIT2BOOL, 1, &p, 1, &e); }
 
     private:

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -96,6 +96,8 @@ enum bv_op_kind {
     OP_BUMUL_OVFL, // unsigned multiplication overflow predicate (negation of OP_BUMUL_NO_OVFL)
     OP_BSMUL_OVFL, // signed multiplication over/underflow predicate
 
+    OP_BSDIV_OVFL, // signed division overflow perdicate
+
     OP_BNEG_OVFL, // negation overflow predicate
 
     OP_BUADD_OVFL, // unsigned addition overflow predicate
@@ -206,6 +208,8 @@ protected:
 
     ptr_vector<func_decl> m_bv_mul_ovfl;
     ptr_vector<func_decl> m_bv_smul_ovfl;
+
+    ptr_vector<func_decl> m_bv_sdiv_ovfl;
 
     ptr_vector<func_decl> m_bv_neg_ovfl;
 
@@ -519,6 +523,7 @@ public:
     app * mk_bvumul_no_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_NO_OVFL, n, m); }
     app * mk_bvsmul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSMUL_OVFL, n, m); }
     app * mk_bvumul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_OVFL, n, m); }
+    app * mk_bvsdiv_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSDIV_OVFL, m, n); }
     app * mk_bvneg_ovfl(expr* m) { return m_manager.mk_app(get_fid(), OP_BNEG_OVFL, m); }
     app * mk_bvuadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUADD_OVFL, n, m); }
     app * mk_bvsadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSADD_OVFL, n, m); }

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -102,6 +102,7 @@ enum bv_op_kind {
     OP_BSADD_OVFL, // signed addition overflow predicate
 
     OP_BUSUB_OVFL, // unsigned subtraction overflow predicate
+    OP_BSSUB_OVFL, // signed subtraction overflow predicate
 
     OP_BIT2BOOL, // predicate
     OP_MKBV,     // bools to bv
@@ -212,6 +213,7 @@ protected:
     ptr_vector<func_decl> m_bv_sadd_ovfl;
 
     ptr_vector<func_decl> m_bv_usub_ovfl;
+    ptr_vector<func_decl> m_bv_ssub_ovfl;
 
     ptr_vector<func_decl>  m_bv_shl;
     ptr_vector<func_decl>  m_bv_lshr;
@@ -521,6 +523,7 @@ public:
     app * mk_bvuadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUADD_OVFL, n, m); }
     app * mk_bvsadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSADD_OVFL, n, m); }
     app * mk_bvusub_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUSUB_OVFL, m, n); }
+    app * mk_bvssub_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSSUB_OVFL, m, n); }
 
     app * mk_bit2bool(expr* e, unsigned idx) { parameter p(idx); return m_manager.mk_app(get_fid(), OP_BIT2BOOL, 1, &p, 1, &e); }
 

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -496,6 +496,7 @@ public:
 
     app * mk_bv2int(expr* e);
 
+    // TODO: all these binary ops commute (right?) but it'd be more logical to swap `n` & `m` in the `return`
     app * mk_bvsmul_no_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSMUL_NO_OVFL, n, m); }
     app * mk_bvsmul_no_udfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSMUL_NO_UDFL, n, m); }
     app * mk_bvumul_no_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_NO_OVFL, n, m); }

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -96,6 +96,8 @@ enum bv_op_kind {
     OP_BUMUL_OVFL, // unsigned multiplication overflow predicate (negation of OP_BUMUL_NO_OVFL)
     OP_BSMUL_OVFL, // signed multiplication over/underflow predicate
 
+    OP_BNEG_OVFL, // negation overflow predicate
+
     OP_BIT2BOOL, // predicate
     OP_MKBV,     // bools to bv
     OP_INT2BV,
@@ -198,6 +200,8 @@ protected:
 
     ptr_vector<func_decl> m_bv_mul_ovfl;
     ptr_vector<func_decl> m_bv_smul_ovfl;
+
+    ptr_vector<func_decl> m_bv_neg_ovfl;
 
     ptr_vector<func_decl>  m_bv_shl;
     ptr_vector<func_decl>  m_bv_lshr;
@@ -503,6 +507,8 @@ public:
     app * mk_bvumul_no_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_NO_OVFL, n, m); }
     app * mk_bvsmul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSMUL_OVFL, n, m); }
     app * mk_bvumul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_OVFL, n, m); }
+    app * mk_bvneg_ovfl(expr* m) { return m_manager.mk_app(get_fid(), OP_BNEG_OVFL, m); }
+
     app * mk_bit2bool(expr* e, unsigned idx) { parameter p(idx); return m_manager.mk_app(get_fid(), OP_BIT2BOOL, 1, &p, 1, &e); }
 
     private:

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -219,6 +219,7 @@ protected:
     func_decl * mk_unary(ptr_vector<func_decl> & decls, decl_kind k, char const * name, unsigned bv_size);
     func_decl * mk_pred(ptr_vector<func_decl> & decls, decl_kind k,
                         char const * name, unsigned bv_size);
+    func_decl * mk_unary_pred(ptr_vector<func_decl> & decls, decl_kind k, char const * name, unsigned bv_size);
     func_decl * mk_reduction(ptr_vector<func_decl> & decls, decl_kind k, char const * name, unsigned bv_size);
     func_decl * mk_comp(unsigned bv_size);
     bool get_bv_size(sort * t, int & result);

--- a/src/ast/bv_decl_plugin.h
+++ b/src/ast/bv_decl_plugin.h
@@ -98,6 +98,8 @@ enum bv_op_kind {
 
     OP_BNEG_OVFL, // negation overflow predicate
 
+    OP_BUADD_OVFL, // unsigned addition overflow predicate
+
     OP_BIT2BOOL, // predicate
     OP_MKBV,     // bools to bv
     OP_INT2BV,
@@ -202,6 +204,8 @@ protected:
     ptr_vector<func_decl> m_bv_smul_ovfl;
 
     ptr_vector<func_decl> m_bv_neg_ovfl;
+
+    ptr_vector<func_decl> m_bv_uadd_ovfl;
 
     ptr_vector<func_decl>  m_bv_shl;
     ptr_vector<func_decl>  m_bv_lshr;
@@ -508,6 +512,7 @@ public:
     app * mk_bvsmul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BSMUL_OVFL, n, m); }
     app * mk_bvumul_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUMUL_OVFL, n, m); }
     app * mk_bvneg_ovfl(expr* m) { return m_manager.mk_app(get_fid(), OP_BNEG_OVFL, m); }
+    app * mk_bvuadd_ovfl(expr* m, expr* n) { return m_manager.mk_app(get_fid(), OP_BUADD_OVFL, n, m); }
 
     app * mk_bit2bool(expr* e, unsigned idx) { parameter p(idx); return m_manager.mk_app(get_fid(), OP_BIT2BOOL, 1, &p, 1, &e); }
 

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -207,6 +207,8 @@ br_status bv_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * cons
         return mk_bvsmul_overflow(num_args, args, result);
     case OP_BUMUL_OVFL:
         return mk_bvumul_overflow(num_args, args, result);
+    case OP_BSDIV_OVFL:
+        return mk_bvsdiv_overflow(num_args, args, result);
     case OP_BUADD_OVFL:
         return mk_bvuadd_overflow(num_args, args, result);
     case OP_BSADD_OVFL:
@@ -3096,6 +3098,15 @@ br_status bv_rewriter::mk_bvssub_overflow(unsigned num, expr * const * args, exp
     SASSERT(bvsaddo_stat != BR_FAILED); (void)bvsaddo_stat;
     auto first_arg_ge_zero = m_util.mk_sle(mk_zero(sz), args[0]);
     result = m.mk_ite(m.mk_eq(args[1], minSigned), first_arg_ge_zero, bvsaddo);
+    return BR_REWRITE_FULL;
+}
+br_status bv_rewriter::mk_bvsdiv_overflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    SASSERT(get_bv_size(args[0]) == get_bv_size(args[1]));
+    auto sz = get_bv_size(args[1]);
+    auto minSigned = mk_numeral(-rational::power_of_two(sz-1), sz);
+    auto minusOne = mk_numeral(-1, sz);
+    result = m.mk_and(m.mk_eq(args[0], minSigned), m.mk_eq(args[1], minusOne));
     return BR_REWRITE_FULL;
 }
 

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -211,6 +211,8 @@ br_status bv_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * cons
         return mk_bvuadd_overflow(num_args, args, result);
     case OP_BSADD_OVFL:
         return mk_bvsadd_over_underflow(num_args, args, result);
+    case OP_BUSUB_OVFL:
+        return mk_bvusub_underflow(num_args, args, result);
     default:
         return BR_FAILED;
     }
@@ -3071,6 +3073,14 @@ br_status bv_rewriter::mk_bvsadd_over_underflow(unsigned num, expr * const * arg
     (void)mk_bvsadd_underflow(2, args, l2);
     result = m.mk_or(l1, l2);
     return BR_REWRITE_FULL;
+}
+
+br_status bv_rewriter::mk_bvusub_underflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    SASSERT(get_bv_size(args[0]) == get_bv_size(args[1]));
+    br_status status = mk_ult(args[0], args[1], result);
+    SASSERT(status != BR_FAILED);
+    return status;
 }
 
 template class poly_rewriter<bv_rewriter_core>;

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -207,6 +207,8 @@ br_status bv_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * cons
         return mk_bvsmul_overflow(num_args, args, result);
     case OP_BUMUL_OVFL:
         return mk_bvumul_overflow(num_args, args, result);
+    case OP_BUADD_OVFL:
+        return mk_bvuadd_overflow(num_args, args, result);
     default:
         return BR_FAILED;
     }
@@ -3011,6 +3013,21 @@ br_status bv_rewriter::mk_bvneg_overflow(expr * const arg, expr_ref & result) {
             mk_ule(maxUnsigned, arg)
     );
     return BR_REWRITE3;
+}
+
+br_status bv_rewriter::mk_bvuadd_overflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    SASSERT(get_bv_size(args[0]) == get_bv_size(args[1]));
+    unsigned sz = get_bv_size(args[0]);
+    auto a1 = mk_zero_extend(1, args[0]);
+    auto a2 = mk_zero_extend(1, args[1]);
+    auto r = mk_bv_add(a1, a2);
+    auto extract = m_mk_extract(sz, sz, r);
+    result = m.mk_and(
+        mk_ule(extract, mk_one(1)),
+        mk_ule(mk_one(1), extract)
+    );
+    return BR_REWRITE_FULL;
 }
 
 template class poly_rewriter<bv_rewriter_core>;

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -2931,13 +2931,13 @@ br_status bv_rewriter::mk_bvsmul_overflow(unsigned num, expr * const * args, exp
             m.mk_not(m_util.mk_bvsmul_no_ovfl(args[0], args[1])),
             m.mk_not(m_util.mk_bvsmul_no_udfl(args[0], args[1]))
     );
-    return BR_REWRITE1;
+    return BR_REWRITE_FULL;
 }
 
 br_status bv_rewriter::mk_bvumul_overflow(unsigned num, expr * const * args, expr_ref & result) {
     SASSERT(num == 2);
     result = m.mk_not(m_util.mk_bvumul_no_ovfl(args[0], args[1]));
-    return BR_REWRITE1;
+    return BR_REWRITE2;
 }
 
 br_status bv_rewriter::mk_bvsmul_no_overflow(unsigned num, expr * const * args, bool is_overflow, expr_ref & result) {

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -209,6 +209,8 @@ br_status bv_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * cons
         return mk_bvumul_overflow(num_args, args, result);
     case OP_BUADD_OVFL:
         return mk_bvuadd_overflow(num_args, args, result);
+    case OP_BSADD_OVFL:
+        return mk_bvsadd_over_underflow(num_args, args, result);
     default:
         return BR_FAILED;
     }
@@ -3027,6 +3029,47 @@ br_status bv_rewriter::mk_bvuadd_overflow(unsigned num, expr * const * args, exp
         mk_ule(extract, mk_one(1)),
         mk_ule(mk_one(1), extract)
     );
+    return BR_REWRITE_FULL;
+}
+
+br_status bv_rewriter::mk_bvsadd_overflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    SASSERT(get_bv_size(args[0]) == get_bv_size(args[1]));
+    unsigned sz = get_bv_size(args[0]);
+    auto zero = mk_zero(sz);
+    auto r = mk_bv_add(args[0], args[1]);
+    auto l1 = m_util.mk_slt(zero, args[0]);
+    auto l2 = m_util.mk_slt(zero, args[1]);
+    auto args_pos = m.mk_and(l1, l2);
+    auto non_pos_sum = m_util.mk_sle(r, zero);
+    result = m.mk_and(args_pos, non_pos_sum);
+    return BR_REWRITE_FULL;
+}
+
+br_status bv_rewriter::mk_bvsadd_underflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    SASSERT(get_bv_size(args[0]) == get_bv_size(args[1]));
+    unsigned sz = get_bv_size(args[0]);
+    auto zero = mk_zero(sz);
+    auto r = mk_bv_add(args[0], args[1]);
+    auto l1 = m_util.mk_slt(args[0], zero);
+    auto l2 = m_util.mk_slt(args[1], zero);
+    auto args_neg = m.mk_and(l1, l2);
+    expr_ref non_neg_sum{result.get_manager()};
+    auto res_rewrite = mk_sge(r, zero, non_neg_sum);
+    assert(res_rewrite != BR_FAILED); (void)res_rewrite;
+    result = m.mk_and(args_neg, non_neg_sum);
+    return BR_REWRITE_FULL;
+}
+
+br_status bv_rewriter::mk_bvsadd_over_underflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    SASSERT(get_bv_size(args[0]) == get_bv_size(args[1]));
+    expr_ref l1{result.get_manager()};
+    expr_ref l2{result.get_manager()};
+    (void)mk_bvsadd_overflow(2, args, l1);
+    (void)mk_bvsadd_underflow(2, args, l2);
+    result = m.mk_or(l1, l2);
     return BR_REWRITE_FULL;
 }
 

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -199,6 +199,10 @@ br_status bv_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * cons
         return mk_bvsmul_no_overflow(num_args, args, false, result);
     case OP_BUMUL_NO_OVFL:
         return mk_bvumul_no_overflow(num_args, args, result);
+    case OP_BSMUL_OVFL:
+        return mk_bvsmul_overflow(num_args, args, result);
+    case OP_BUMUL_OVFL:
+        return mk_bvumul_overflow(num_args, args, result);
     default:
         return BR_FAILED;
     }
@@ -2919,6 +2923,21 @@ br_status bv_rewriter::mk_distinct(unsigned num_args, expr * const * args, expr_
         return BR_FAILED;
     result = m.mk_false();
     return BR_DONE;     
+}
+
+br_status bv_rewriter::mk_bvsmul_overflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    result = m.mk_or(
+            m.mk_not(m_util.mk_bvsmul_no_ovfl(args[0], args[1])),
+            m.mk_not(m_util.mk_bvsmul_no_udfl(args[0], args[1]))
+    );
+    return BR_REWRITE1;
+}
+
+br_status bv_rewriter::mk_bvumul_overflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    result = m.mk_not(m_util.mk_bvumul_no_ovfl(args[0], args[1]));
+    return BR_REWRITE1;
 }
 
 br_status bv_rewriter::mk_bvsmul_no_overflow(unsigned num, expr * const * args, bool is_overflow, expr_ref & result) {

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -213,6 +213,8 @@ br_status bv_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * cons
         return mk_bvsadd_over_underflow(num_args, args, result);
     case OP_BUSUB_OVFL:
         return mk_bvusub_underflow(num_args, args, result);
+    case OP_BSSUB_OVFL:
+        return mk_bvssub_overflow(num_args, args, result);
     default:
         return BR_FAILED;
     }
@@ -3081,6 +3083,20 @@ br_status bv_rewriter::mk_bvusub_underflow(unsigned num, expr * const * args, ex
     br_status status = mk_ult(args[0], args[1], result);
     SASSERT(status != BR_FAILED);
     return status;
+}
+
+br_status bv_rewriter::mk_bvssub_overflow(unsigned num, expr * const * args, expr_ref & result) {
+    SASSERT(num == 2);
+    SASSERT(get_bv_size(args[0]) == get_bv_size(args[1]));
+    auto sz = get_bv_size(args[0]);
+    auto minSigned = mk_numeral(-rational::power_of_two(sz-1), sz);
+    expr_ref bvsaddo { result.get_manager() };
+    expr * args2[2] = { args[0], m_util.mk_bv_neg(args[1]) };
+    auto bvsaddo_stat = mk_bvsadd_overflow(2, args2, bvsaddo);
+    SASSERT(bvsaddo_stat != BR_FAILED); (void)bvsaddo_stat;
+    auto first_arg_ge_zero = m_util.mk_sle(mk_zero(sz), args[0]);
+    result = m.mk_ite(m.mk_eq(args[1], minSigned), first_arg_ge_zero, bvsaddo);
+    return BR_REWRITE_FULL;
 }
 
 template class poly_rewriter<bv_rewriter_core>;

--- a/src/ast/rewriter/bv_rewriter.cpp
+++ b/src/ast/rewriter/bv_rewriter.cpp
@@ -93,6 +93,10 @@ br_status bv_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * cons
     case OP_BNEG:
         SASSERT(num_args == 1);
         return mk_uminus(args[0], result);
+    case OP_BNEG_OVFL:
+        SASSERT(num_args == 1);
+        return mk_bvneg_overflow(args[0], result);
+
     case OP_BSHL:
         SASSERT(num_args == 2);
         return mk_bv_shl(args[0], args[1], result);
@@ -2999,5 +3003,14 @@ br_status bv_rewriter::mk_bvumul_no_overflow(unsigned num, expr * const * args, 
     return BR_FAILED;
 }
 
+br_status bv_rewriter::mk_bvneg_overflow(expr * const arg, expr_ref & result) {
+    unsigned int sz = get_bv_size(arg);
+    auto maxUnsigned = mk_numeral(rational::power_of_two(sz)-1, sz);
+    result = m.mk_and(
+            mk_ule(arg, maxUnsigned),
+            mk_ule(maxUnsigned, arg)
+    );
+    return BR_REWRITE3;
+}
 
 template class poly_rewriter<bv_rewriter_core>;

--- a/src/ast/rewriter/bv_rewriter.h
+++ b/src/ast/rewriter/bv_rewriter.h
@@ -139,6 +139,10 @@ class bv_rewriter : public poly_rewriter<bv_rewriter_core> {
     br_status mk_mkbv(unsigned num, expr * const * args, expr_ref & result);
     br_status mk_bvsmul_no_overflow(unsigned num, expr * const * args, bool is_overflow, expr_ref & result);
     br_status mk_bvumul_no_overflow(unsigned num, expr * const * args, expr_ref & result);
+
+    br_status mk_bvsmul_overflow(unsigned num, expr * const * args, expr_ref & result);
+    br_status mk_bvumul_overflow(unsigned num, expr * const * args, expr_ref & result);
+
     bool is_minus_one_times_t(expr * arg);
     void mk_t1_add_t2_eq_c(expr * t1, expr * t2, expr * c, expr_ref & result);
 

--- a/src/ast/rewriter/bv_rewriter.h
+++ b/src/ast/rewriter/bv_rewriter.h
@@ -145,6 +145,8 @@ class bv_rewriter : public poly_rewriter<bv_rewriter_core> {
 
     br_status mk_bvneg_overflow(expr * const arg, expr_ref & result);
 
+    br_status mk_bvuadd_overflow(unsigned num, expr * const * args, expr_ref & result);
+
     bool is_minus_one_times_t(expr * arg);
     void mk_t1_add_t2_eq_c(expr * t1, expr * t2, expr * c, expr_ref & result);
 

--- a/src/ast/rewriter/bv_rewriter.h
+++ b/src/ast/rewriter/bv_rewriter.h
@@ -146,6 +146,9 @@ class bv_rewriter : public poly_rewriter<bv_rewriter_core> {
     br_status mk_bvneg_overflow(expr * const arg, expr_ref & result);
 
     br_status mk_bvuadd_overflow(unsigned num, expr * const * args, expr_ref & result);
+    br_status mk_bvsadd_overflow(unsigned num, expr * const * args, expr_ref & result);
+    br_status mk_bvsadd_underflow(unsigned num, expr * const * args, expr_ref & result);
+    br_status mk_bvsadd_over_underflow(unsigned num, expr * const * args, expr_ref & result);
 
     bool is_minus_one_times_t(expr * arg);
     void mk_t1_add_t2_eq_c(expr * t1, expr * t2, expr * c, expr_ref & result);

--- a/src/ast/rewriter/bv_rewriter.h
+++ b/src/ast/rewriter/bv_rewriter.h
@@ -150,6 +150,8 @@ class bv_rewriter : public poly_rewriter<bv_rewriter_core> {
     br_status mk_bvsadd_underflow(unsigned num, expr * const * args, expr_ref & result);
     br_status mk_bvsadd_over_underflow(unsigned num, expr * const * args, expr_ref & result);
 
+    br_status mk_bvusub_underflow(unsigned num, expr * const * args, expr_ref & result);
+
     bool is_minus_one_times_t(expr * arg);
     void mk_t1_add_t2_eq_c(expr * t1, expr * t2, expr * c, expr_ref & result);
 

--- a/src/ast/rewriter/bv_rewriter.h
+++ b/src/ast/rewriter/bv_rewriter.h
@@ -143,6 +143,8 @@ class bv_rewriter : public poly_rewriter<bv_rewriter_core> {
     br_status mk_bvsmul_overflow(unsigned num, expr * const * args, expr_ref & result);
     br_status mk_bvumul_overflow(unsigned num, expr * const * args, expr_ref & result);
 
+    br_status mk_bvneg_overflow(expr * const arg, expr_ref & result);
+
     bool is_minus_one_times_t(expr * arg);
     void mk_t1_add_t2_eq_c(expr * t1, expr * t2, expr * c, expr_ref & result);
 

--- a/src/ast/rewriter/bv_rewriter.h
+++ b/src/ast/rewriter/bv_rewriter.h
@@ -151,6 +151,7 @@ class bv_rewriter : public poly_rewriter<bv_rewriter_core> {
     br_status mk_bvsadd_over_underflow(unsigned num, expr * const * args, expr_ref & result);
 
     br_status mk_bvusub_underflow(unsigned num, expr * const * args, expr_ref & result);
+    br_status mk_bvssub_overflow(unsigned num, expr * const * args, expr_ref & result);
 
     bool is_minus_one_times_t(expr * arg);
     void mk_t1_add_t2_eq_c(expr * t1, expr * t2, expr * c, expr_ref & result);

--- a/src/ast/rewriter/bv_rewriter.h
+++ b/src/ast/rewriter/bv_rewriter.h
@@ -143,6 +143,8 @@ class bv_rewriter : public poly_rewriter<bv_rewriter_core> {
     br_status mk_bvsmul_overflow(unsigned num, expr * const * args, expr_ref & result);
     br_status mk_bvumul_overflow(unsigned num, expr * const * args, expr_ref & result);
 
+    br_status mk_bvsdiv_overflow(unsigned num, expr * const * args, expr_ref & result);
+
     br_status mk_bvneg_overflow(expr * const arg, expr_ref & result);
 
     br_status mk_bvuadd_overflow(unsigned num, expr * const * args, expr_ref & result);


### PR DESCRIPTION
Smtlib2 is being extended to include overflow predicates for bit vectors (see https://groups.google.com/u/1/g/smt-lib/c/J4D99wT0aKI). This PR introduces the predicates `bvumulo`, `bvsmulo`, `bvsdivo`, `bvnego`, `bvuaddo`, `bvsaddo`, `bvusubo`, and `bvssubo` for Z3.